### PR TITLE
Fix manage-tools so invoking setup no longer invokes usage and dies, …

### DIFF
--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -48,7 +48,7 @@ then
 		[ "$ALLOW_SUDO" -eq 0 ] && $0 $ACTION $t
 	done
 	exit
-elif [ -z "$TOOL" -a "$ACTION" != "list" ]
+elif [ -z "$TOOL" -a "$ACTION" != "list" -a "$ACTION" != "setup" ]
 then
 	usage
 	exit


### PR DESCRIPTION
…but actually does setup.

manage-tools setup was broken and was displaying the usage instead of writing to bashrc. This fixes that.
