### PR TITLE
Now install gdb with support for debugging multiple architectures

### DIFF
--- a/gdb/install
+++ b/gdb/install
@@ -2,6 +2,6 @@
 
 curl http://ftp.gnu.org/gnu/gdb/gdb-7.9.tar.gz | tar xvz
 cd gdb-7.9
-./configure --prefix=$(dirname $PWD) --with-python=python2
+./configure --prefix=$(dirname $PWD) --with-python=python2 --enable-targets=all
 make -j $(nproc)
 make install


### PR DESCRIPTION
Add the --enable-targets=all flag to configure invokation. This will allow gdb to debug architecture's other than the host's. Helpful when debugging processes running under qemu for example.
