### PR TITLE
Fix git clone RSA key error on Kali

### DIFF
--- a/dirs3arch/install
+++ b/dirs3arch/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir bin
-git clone git@github.com:maurosoria/dirs3arch.git
+git clone https://github.com/maurosoria/dirs3arch.git
 
 cd bin
 ln -s ../dirs3arch/dirs3arch.py .


### PR DESCRIPTION
Matches the git clone method as used in other scripts.
