### PR TITLE
Fix missing LIB_VEX error

### DIFF
--- a/codereason/install
+++ b/codereason/install
@@ -2,6 +2,7 @@
 
 git clone https://github.com/trailofbits/codereason
 cd codereason
+./install_vex.sh
 ./make.sh
 cd ..
 


### PR DESCRIPTION
codereason uses a modified lib_vex that isn't installed system wide, compiled with the make.sh and breaks the install if not there.
