### PR TITLE
Update valgrind to 3.11, make github use https

### DIFF
--- a/taintgrind/install
+++ b/taintgrind/install
@@ -2,14 +2,14 @@
 
 INST_DIR=$PWD
 
-curl http://valgrind.org/downloads/valgrind-3.10.0.tar.bz2 | tar xvj
-cd valgrind-3.10.0
+curl http://valgrind.org/downloads/valgrind-3.11.0.tar.bz2 | tar xvj
+cd valgrind-3.11.0
 ./autogen.sh
 ./configure --prefix=$INST_DIR
 make -j $(nproc)
 make install
 
-git clone http://github.com/wmkhoo/taintgrind.git
+git clone https://github.com/wmkhoo/taintgrind.git
 cd taintgrind
 ../autogen.sh
 ./configure --prefix=$INST_DIR


### PR DESCRIPTION
Should work - compiled on Kali 1.10 haven't tested it yet.
