### PR TITLE
Update sonic visualiser to 2.5

### DIFF
--- a/sonic-visualizer/install
+++ b/sonic-visualizer/install
@@ -2,13 +2,13 @@
 
 INST_DIR=$PWD
 
-wget --no-check-certificate -O - https://code.soundsoftware.ac.uk/attachments/download/1185/sonic-visualiser-2.4.1.tar.gz | tar xz
-cd sonic-visualiser-2.4.1
+wget --no-check-certificate -O - https://code.soundsoftware.ac.uk/attachments/download/1675/sonic-visualiser-2.5.tar.gz | tar xz
+cd sonic-visualiser-2.5
 ./configure --prefix=$INST_DIR
 make -j
 #make install
 
 mkdir -p bin
 cd bin
-ln -s ../sonic-visualiser-2.4.1/sonic-visualiser .
+ln -s ../sonic-visualiser-2.5/sonic-visualiser .
 cd ..


### PR DESCRIPTION
Can someone check if it compiles properly or any new dependencies - my Kali install doesn't play nice with qmake-qt5.

According to changelog shouldn't be too many changes so should just work.

https://code.soundsoftware.ac.uk/projects/sonic-visualiser/repository/entry/CHANGELOG
