### PR TITLE
Fixed missing escaping of $@ in the gdb extension install scripts

### DIFF
--- a/gef/install
+++ b/gef/install
@@ -6,7 +6,7 @@ git clone --depth 1 https://github.com/hugsy/gef.git
 mkdir bin
 cat > bin/gdb-gef <<EOF
 #!/bin/sh
-exec gdb -q -ex init-gef "$@"
+exec gdb -q -ex init-gef "\$@"
 EOF
 chmod +rx bin/gdb-gef
 

--- a/peda/install
+++ b/peda/install
@@ -6,7 +6,7 @@ git clone --depth 1 https://github.com/longld/peda.git
 mkdir bin
 cat > bin/gdb-peda <<EOF
 #!/bin/sh
-exec gdb -q -ex init-peda "$@"
+exec gdb -q -ex init-peda "\$@"
 EOF
 chmod +rx bin/gdb-peda
 

--- a/pwndbg/install
+++ b/pwndbg/install
@@ -6,7 +6,7 @@ git clone --depth 1 git clone https://github.com/zachriggle/pwndbg
 mkdir bin
 cat >> bin/pwndbg <<EOF
 #!/bin/sh
-exec gdb -q -ex init-pwndbg "$@"
+exec gdb -q -ex init-pwndbg "\$@"
 EOF
 chmod +rx bin/pwndbg
 


### PR DESCRIPTION
This is embarrassing. I have overlooked this in my previous pull-request.
