### PR TITLE
Update README to point out Kali's issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ And connect to it via:
 vagrant ssh
 ```
 
+## Kali Linux
+
+Kali Linux (Sana and Rolling), due to manually setting certain libraries to not use the latest version available (sometimes being out of date by years) causes some tools to not install at all, or fail in strange ways. AFL and Panda comes to mind, in fact any tool that uses QEMU 2.30 will probably fail during compilation under Kali.
+Overriding these libraries breaks other tools included in Kali so your only solution is to either live with some of Kali's tools being broken, or running another distribution seperately such as Ubuntu. 
+
+Most tools aren't affected though.
+
 ## Adding Tools
 
 To add a tool (say, named *toolname*), do the following:


### PR DESCRIPTION
After attempting to debug AFL and Panda for 2+ days the "solution" was finally found to the compilation issues...

For reference - 

https://patchwork.kernel.org/patch/8982051/
http://oss.sgi.com/archives/xfs/2016-04/msg00598.html

From this and checking my libraries it's clear Kali is running with some very outdated libraries.
To be fair it was never intended to be used day-to-day, but for pentesting purposes.

Issues with compilation with Kali is from experience because of this - so there's not much one can do.
Mucking around with libraries especially in Kali breaks some tools due to being outdated (then again some pentesting tools were written as PoC in the first place...). Dynamic Linking strikes again!
