### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,8 @@ dist: trusty
 env:
 - PATH=$TRAVIS_BUILD_DIR/bin:$PATH
 install: (sudo apt-get update || true) && bin/manage-tools -s setup
-script: VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test all
+script:
+- VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test z3
+- VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test qemu
+- VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test qira
+- VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test all

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ dist: trusty
 env:
 - PATH=$TRAVIS_BUILD_DIR/bin:$PATH
 install: (sudo apt-get update || true) && bin/manage-tools -s setup
-script: VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s test all
+script: VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s -v test all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: python
-python: 2.7
+language: bash
 sudo: required
-dist: xenial
+dist: trusty
 env:
 - PATH=$TRAVIS_BUILD_DIR/bin:$PATH
 install: (sudo apt-get update || true) && bin/manage-tools -s setup
-script: manage-tools -s test all
+script: VIRTUALENVWRAPPER_SCRIPT=/usr/share/virtualenvwrapper/virtualenvwrapper.sh manage-tools -s test all

--- a/barf/install
+++ b/barf/install
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # it's z3!
-pip install https://github.com/zardus/z3/archive/pypy-and-setup.zip
+ctf-tools-pip install https://github.com/zardus/z3/archive/pypy-and-setup.zip
+
+source ${VIRTUALENVWRAPPER_SCRIPT}
+workon ctftools
 
 # pybfd can't be installed with pip
 git clone --depth 1 https://github.com/Groundworkstech/pybfd
@@ -9,11 +12,16 @@ cd pybfd/
 python setup.py install
 cd ..
 
+# install pyasmjit
+git clone --depth 1 https://github.com/programa-stic/pyasmjit.git
+cd pyasmjit
+python setup.py install
+cd ..
+
 # install barf
 git clone --depth 1 https://github.com/programa-stic/barf-project
 cd barf-project/
-pip install -e pyasmjit/
-pip install -e barf/
+python setup.py install
 cd ..
 
 mkdir -p bin

--- a/barf/uninstall
+++ b/barf/uninstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip uninstall -y barf pyasmjit
+ctf-tools-pip uninstall -y barf pyasmjit
 rm -f $VIRTUAL_ENV/bin/BARFgadgets

--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -5,10 +5,11 @@ set -eu -o pipefail
 function usage()
 {
 	cat <<END
-Usage: $(basename $0) [-s] (list|setup|install|uninstall|bin|search) tool
+Usage: $(basename $0) [-sv] (list|setup|install|uninstall|bin|search) tool
 
 Where:
     -s      allow running things with sudo (i.e., to install debs)
+    -v      verbose mode. print log while installing
     tool    the name of the tool. if "all", does the action on all tools
 
 Actions:
@@ -158,6 +159,9 @@ do
 		-s)
 			export ALLOW_SUDO=1
 			;;
+		-v)
+			export VERBOSE_OUTPUT=1
+			;;
 		*)
 			usage
 			exit
@@ -167,6 +171,7 @@ do
 done
 
 [[ -z ${ALLOW_SUDO+x} ]] && export ALLOW_SUDO=0
+[[ -z ${VERBOSE_OUTPUT+x} ]] && export VERBOSE_OUTPUT=0
 
 if [[ $# -ge 1 ]]; then
 	ACTION="$1"
@@ -246,8 +251,12 @@ case $ACTION in
 		fi
 
 		# execute install script
-		if env DISTRI=$DISTRI ./install >>install.log 2>&1
-		then
+		if [ "$VERBOSE_OUTPUT" -eq 1 ]; then
+			env DISTRI=$DISTRI ./install 2>&1 | tee -a install.log
+		else
+			env DISTRI=$DISTRI ./install >>install.log 2>&1
+		fi
+		if [ "$?" -eq 0 ]; then
 			tool_log "install finished"
 		else
 			tool_log "INSTALL FAILED"

--- a/binwalk/install
+++ b/binwalk/install
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 git clone --depth 1 https://github.com/devttys0/binwalk.git
-pip install -e binwalk
+ctf-tools-pip install -e binwalk
 
 mkdir -p bin
 ln -s $VIRTUAL_ENV/bin/binwalk bin

--- a/capstone/install
+++ b/capstone/install
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-ctf-tools-pip install -U capstone
-ctf-tools-pip3 install -U capstone
+ctf-tools-pip install --no-use-wheel -U capstone
+ctf-tools-pip3 install --no-use-wheel -U capstone

--- a/panda/install
+++ b/panda/install
@@ -11,7 +11,7 @@ cp distorm3/make/linux/*.so distorm3/*.a lib
 mkdir -p include
 cp distorm3/include/*.h include
 
-pip install -U pycparser
+ctf-tools-pip install -U pycparser
 
 sed -i -e "s|/usr/local|$PWD|" panda/qemu/build.sh
 export QEMU_CFLAGS="-I $PWD/include -L $PWD/lib"

--- a/ropper/install
+++ b/ropper/install
@@ -2,6 +2,6 @@
 
 [ -e ropper ] || git clone --depth 1 https://github.com/sashs/Ropper.git ropper
 
-pip install --no-use-wheel --no-cache-dir -I capstone
-pip install filebytes
-pip install -e ropper
+ctf-tools-pip install --no-use-wheel --no-cache-dir -I capstone
+ctf-tools-pip install filebytes
+ctf-tools-pip install -e ropper

--- a/ropper/test
+++ b/ropper/test
@@ -1,4 +1,9 @@
 #!/bin/bash -e
 
+set +e
+source ${VIRTUALENVWRAPPER_SCRIPT}
+workon ctftools
+set -e
+
 [ $(ropper --file /bin/false | wc -l) -gt 400 ] || exit 1
 exit 0

--- a/shellsploit/install
+++ b/shellsploit/install
@@ -2,6 +2,11 @@
 
 git clone https://github.com/b3mb4m/shellsploit-framework.git
 cd shellsploit-framework
+
+set +e
+source ${VIRTUALENVWRAPPER_SCRIPT}
+workon ctftools
+set -e
 python easyinstall.py install
 cd ..
 
@@ -9,3 +14,4 @@ mkdir -p bin
 cd bin
 ln -sf $VIRTUAL_ENV/bin/shellsploit .
 cd ..
+deactivate

--- a/sqlmap/install
+++ b/sqlmap/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 git clone --depth 1 https://github.com/sqlmapproject/sqlmap.git
-pip install pymysql psycopg2 pysqlite2 python-ntlm
+ctf-tools-pip install pymysql psycopg2 pysqlite2 python-ntlm
 mkdir bin
 cd bin
 ln -s ../sqlmap/sqlmap.py .

--- a/virtualsocket/install
+++ b/virtualsocket/install
@@ -1,3 +1,3 @@
 git clone --depth 1 https://github.com/antoniobianchi333/virtualsocket.git
-pip install -e virtualsocket/
+ctf-tools-pip install -e virtualsocket/
 


### PR DESCRIPTION
This PR tries to fix (for real this time) the tests.

Some notes:
- i used `bash` + `trusty` (+ `sudo`) so that travis should use a Ubuntu VM. `xenial` AFAIK is not available yet
- VIRTUALENVWRAPPER_SCRIPT is not available on travis for whatever reason.. :( I had to set it manually so that i can switch between virtualenv easily inside tests and install scripts
- i converted existing install scripts from system pip to `ctf-tools-pip`.

Unfortunately sometimes the build can still fail because pyvmmonitor uses google drive and that link is _very_ unreliable.. don't know what to do about it.
