### PR TITLE
Add libheap GDB library

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Installers for the following tools are included:
 | binary | [gdb](http://www.gnu.org/software/gdb/) | Up-to-date gdb with python2 bindings. | <!--tool--><!--failing-->
 | binary | [gef](https://github.com/hugsy/gef) | Enhanced environment for gdb. | <!--tool--><!--no-test-->
 | binary | [hongfuzz](https://github.com/google/honggfuzz) | A general-purpose, easy-to-use fuzzer with interesting analysis options. | <!--tool--><!--test-->
+| binary | [libheap](https://github.com/cloudburst/libheap) | gdb python library for examining the glibc heap (ptmalloc) | <!--tool--><!--no-test-->
 | binary | [panda](https://github.com/moyix/panda) | Platform for Architecture-Neutral Dynamic Analysis. | <!--tool--><!--no-test-->
 | binary | [pathgrind](https://github.com/codelion/pathgrind) | Path-based, symbolically-assisted fuzzer. | <!--tool--><!--test-->
 | binary | [peda](https://github.com/longld/peda) | Enhanced environment for gdb. | <!--tool--><!--test-->

--- a/gdb/install
+++ b/gdb/install
@@ -2,6 +2,11 @@
 
 curl https://ftp.gnu.org/gnu/gdb/gdb-7.11.1.tar.gz | tar xz
 cd gdb-7.11.1
+
+# move to ctftools virtual env
+source ${VIRTUALENVWRAPPER_SCRIPT}
+workon ctftools
+
 ./configure --prefix=$(dirname $PWD) --with-python=python2 --enable-targets=all
 make -j $(nproc)
 make install

--- a/libheap/install
+++ b/libheap/install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+git clone https://github.com/cloudburst/libheap
+
+# move to ctftools virtual env
+source ${VIRTUALENVWRAPPER_SCRIPT}
+workon ctftools
+
+cd libheap
+python setup.py install


### PR DESCRIPTION
I needed to build GDB with the python from the `ctftools` virtualenv, otherwise the libheap is not available... Is it a problem?

Also, travis is failing on my tests, but I think it's still because of pyvmmonitor's link that is not reliable at all :(
