### PR TITLE
add veles and zsteg

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Installers for the following tools are included:
 | stego | [steganabara](http://www.caesum.com/handbook/stego.htm) | Another image steganography solver. | <!--tool--><!--test-->
 | stego | [stegdetect](http://www.outguess.org/) | Steganography detection/breaking tool. | <!--tool--><!--test-->
 | stego | [stegsolve](http://www.caesum.com/handbook/stego.htm) | Image steganography solver. | <!--tool--><!--test-->
-| stego | [zsteg](https://github.com/zed-0xff/zsteg) | detect stegano-hidden data in PNG & BMP. | <!--tool--><!--test-->
+| stego | [zsteg](https://github.com/zed-0xff/zsteg) | detect stegano-hidden data in PNG & BMP. | <!--tool--><!--no-test-->
 | android | [apktool](https://ibotpeaches.github.io/Apktool/) | Dissect, dis-assemble, and re-pack Android APKs | <!--tool--><!--test-->
 | android | [android-sdk](http://developer.android.com/sdk) | The android SDK (adb, emulator, etc). | <!--tool--><!--no-test-->
 | misc | [z3](https://github.com/Z3Prover/z3) | Theorem prover from Microsoft Research. | <!--tool--><!--times-out-->

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Installers for the following tools are included:
 | stego | [steganabara](http://www.caesum.com/handbook/stego.htm) | Another image steganography solver. | <!--tool--><!--test-->
 | stego | [stegdetect](http://www.outguess.org/) | Steganography detection/breaking tool. | <!--tool--><!--test-->
 | stego | [stegsolve](http://www.caesum.com/handbook/stego.htm) | Image steganography solver. | <!--tool--><!--test-->
+| stego | [zsteg](https://github.com/zed-0xff/zsteg) | detect stegano-hidden data in PNG & BMP. | <!--tool--><!--test-->
 | android | [apktool](https://ibotpeaches.github.io/Apktool/) | Dissect, dis-assemble, and re-pack Android APKs | <!--tool--><!--test-->
 | android | [android-sdk](http://developer.android.com/sdk) | The android SDK (adb, emulator, etc). | <!--tool--><!--no-test-->
 | misc | [z3](https://github.com/Z3Prover/z3) | Theorem prover from Microsoft Research. | <!--tool--><!--times-out-->
 | misc | [jdgui](http://jd.benow.ca/) | Java decompiler. | <!--tool--><!--test-->
+| misc | [veles](https://codisec.com/veles/) | Binary data analysis and visulalization tool. | <!--tool--><!--test-->
 
 There are also a couple of installers for useful libraries included. Currently
 only the python bindings for these libraries are installed.

--- a/radare2/install
+++ b/radare2/install
@@ -18,4 +18,4 @@ END
 	chmod 755 $i
 done
 
-ctf-tools-pip install -yU r2pipe
+ctf-tools-pip install -U r2pipe

--- a/veles/install
+++ b/veles/install
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+wget -O src.tar.gz https://codisec.com/wp-content/uploads/2016/12/Veles_2016.12_Source.tar.gz
+tar xf src.tar.gz
+mkdir build
+cd build
+cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX:PATH=.. ../veles-2016.12
+make -j8
+make install

--- a/veles/install-root-archlinux
+++ b/veles/install-root-archlinux
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+pacman -Syu --noconfirm --needed cmake zlib qt5-base

--- a/veles/install-root-debian
+++ b/veles/install-root-debian
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apt-get install -y cmake zlib zlib-dev qtbase5 qtbase5-dev

--- a/zsteg/install
+++ b/zsteg/install
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+gem install zsteg

--- a/zsteg/install-root-archlinux
+++ b/zsteg/install-root-archlinux
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+pacman -Syu --noconfirm --needed ruby

--- a/zsteg/install-root-debian
+++ b/zsteg/install-root-debian
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apt-get install -y ruby


### PR DESCRIPTION
note that zsteg won't work on ubuntu trusty, because it tries to install the gem globally to the system, while on arch with ruby 2.3 it will install it somewhere in the user home. I'm not familiar with the ruby ecosystem, so maybe someone else can figure out how to achieve something similar to our setup with the python virtualenv.

adding veles is straightforward.

fixes #89 #92 