### PR TITLE
fedora support + improvements around heap gdb extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Installers for the following tools are included:
 | binary | [elfparser](http://www.elfparser.com/) | Quickly determine the capabilities of an ELF binary through static analysis. | <!--tool--><!--test-->
 | binary | [evilize](http://www.mathstat.dal.ca/~selinger/md5collision/) | Tool to create MD5 colliding binaries | <!--tool--><!--test-->
 | binary | [gdb](http://www.gnu.org/software/gdb/) | Up-to-date gdb with python2 bindings. | <!--tool--><!--failing-->
+| binary | [gdb-heap](https://fedorahosted.org/gdb-heap/) | gdb extension for debugging heap issues. | <!--tool--><!--test-->
 | binary | [gef](https://github.com/hugsy/gef) | Enhanced environment for gdb. | <!--tool--><!--no-test-->
 | binary | [hongfuzz](https://github.com/google/honggfuzz) | A general-purpose, easy-to-use fuzzer with interesting analysis options. | <!--tool--><!--test-->
 | binary | [libheap](https://github.com/cloudburst/libheap) | gdb python library for examining the glibc heap (ptmalloc) | <!--tool--><!--no-test-->

--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -42,6 +42,8 @@ function detect_distribution()
 		else
 			echo "debian"
 		fi
+	elif which dnf 2>&1 >/dev/null; then
+		echo "fedora"
 	else
 		echo ""
 	fi

--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -112,6 +112,19 @@ EOF
 }
 
 
+function base_build_setup_fedora()
+{
+	PACKAGE_REQS="libtool gcc gcc-c++ texinfo curl wget automake autoconf python python-devel git subversion unzip python-virtualenvwrapper"
+	if [ "$ALLOW_SUDO" -eq 1 ]; then
+		sudo dnf -y install $PACKAGE_REQS
+	else
+		TOOL=SETUP tool_log "Please install the following packages: $PACKAGE_REQS"
+	fi
+
+	# TODO: check whether we have to explicitly enable i386 package support
+}
+
+
 function base_build_setup()
 {
 	case "$1" in
@@ -123,6 +136,9 @@ function base_build_setup()
 		"archlinux")
 			base_build_setup_arch
 			export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+			;;
+		"fedora")
+			base_build_setup_fedora
 			;;
 		*)
 			TOOL=SETUP tool_log "Cannot detect or unsupported distribution"

--- a/gdb-heap/install
+++ b/gdb-heap/install
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+git clone --depth=1 http://git.fedorahosted.org/git/gdb-heap.git || true
+
+cd gdb-heap
+# make sure gdbinit exists
+touch ~/.gdbinit
+if ! grep "init-gdb-heap" ~/.gdbinit; then
+    cat >> ~/.gdbinit <<EOF
+
+####
+# added by ctf-tools
+define init-gdb-heap
+    python import sys; sys.path.append("$PWD"); import heap
+end
+document init-gdb-heap
+    Initializes the gdb-heap extension (https://fedorahosted.org/gdb-heap/)
+end
+####
+
+EOF
+fi

--- a/gdb-heap/install-root-debian
+++ b/gdb-heap/install-root-debian
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apt-get install -y libc6-dbg

--- a/gdb-heap/install-root-fedora
+++ b/gdb-heap/install-root-fedora
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+dnf install -y dnf-plugins-core
+dnf debuginfo-install -y glibc

--- a/gdb/install-root-fedora
+++ b/gdb/install-root-fedora
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+dnf install -y texinfo

--- a/libheap/install
+++ b/libheap/install
@@ -17,7 +17,7 @@ if ! grep "init-libheap" ~/.gdbinit; then
 define init-libheap
     python from libheap import *
 end
-document init-pwndbg
+document init-libheap
     Initializes the libheap gdb extension (https://github.com/cloudburst/libheap)
 end
 ####

--- a/libheap/install
+++ b/libheap/install
@@ -5,3 +5,22 @@ source ctf-tools-venv-activate
 
 git clone --depth 1 https://github.com/cloudburst/libheap
 pip install -e libheap
+
+# make sure gdbinit exists
+touch ~/.gdbinit
+# check if init command exits
+if ! grep "init-libheap" ~/.gdbinit; then
+    cat >> ~/.gdbinit <<EOF
+
+####
+# added by ctf-tools
+define init-libheap
+    python from libheap import *
+end
+document init-pwndbg
+    Initializes the libheap gdb extension (https://github.com/cloudburst/libheap)
+end
+####
+
+EOF
+fi

--- a/libheap/install-root-debian
+++ b/libheap/install-root-debian
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apt-get install libc6-dbg

--- a/libheap/install-root-debian
+++ b/libheap/install-root-debian
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-apt-get install libc6-dbg
+apt-get install -y libc6-dbg

--- a/libheap/install-root-fedora
+++ b/libheap/install-root-fedora
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 dnf install -y dnf-plugins-core
-dnf debuginfo-install glibc
+dnf debuginfo-install -y glibc

--- a/libheap/install-root-fedora
+++ b/libheap/install-root-fedora
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+dnf install -y dnf-plugins-core
+dnf debuginfo-install glibc

--- a/pwndbg/install-root-debian
+++ b/pwndbg/install-root-debian
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apt-get install -y libc6-dbg

--- a/pwndbg/install-root-fedora
+++ b/pwndbg/install-root-fedora
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+dnf install -y dnf-plugins-core
+dnf debuginfo-install -y glibc

--- a/pwntools/install-root-fedora
+++ b/pwntools/install-root-fedora
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+dnf install -y binutils binutils-devel libffi-devel openssl-devel

--- a/snowman/install-root-fedora
+++ b/snowman/install-root-fedora
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu -o pipefail
+
+dnf install -y boost cmake qt5-base qqt5-base-devel

--- a/wcc/install
+++ b/wcc/install
@@ -1,9 +1,17 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 git clone --depth 1 https://github.com/endrazine/wcc
 pushd wcc
 git submodule init
 git submodule update
+
+# fedora doesn't have stropts.h since apparently it's unsupported on linux
+# anyway. wcc compiles fines without it.
+if [[ "$DISTRI" == "fedora" ]]; then
+    sed -i "s&#include <stropts.h>&/*#include <stropts.h>*/&g" \
+        src/wsh/include/libwitch/wsh.h
+fi
+
 
 make
 mv bin/ ../

--- a/wcc/install
+++ b/wcc/install
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 git clone --depth 1 https://github.com/endrazine/wcc
 pushd wcc

--- a/wcc/install-root-fedora
+++ b/wcc/install-root-fedora
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu -o pipefail
+
+dnf install -y clang clang-libs clang-devel binutils binutils-devel \
+    uthash-devel elfutils-libelf elfutils-libelf-devel capstone \
+    capstone-devel readline readline-devel gsl gsl-devel


### PR DESCRIPTION
- fedora support in manage-tools
- a couple of `install-root-fedora`s
- debug info install for the libc, for all gdb extensions that deal with heap stuff (pwndbg, libheap)
- added the gdb-heap extension