### PR TITLE
Fix manage-tools bug

### DIFF
--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -129,7 +129,7 @@ function base_build_setup()
 {
 	case "$1" in
 		"ubuntu")
-			;&  # fallthrough
+			;;  # fallthrough
 		"debian")
 			base_build_setup_debian
 			;;


### PR DESCRIPTION
I can't install on my macOS with fish shell, and after this change, I can install it.