### PR TITLE
Updated tools and installers

### DIFF
--- a/Dockerfile.archlinux
+++ b/Dockerfile.archlinux
@@ -1,7 +1,11 @@
 from base/archlinux
 
-RUN echo 'Server = http://mirror1.htu.tugraz.at/archlinux/$repo/os/$arch' \
-    > /etc/pacman.d/mirrorlist
+RUN cat /etc/pacman.d/mirrorlist \ 
+        | sed 's/^#Server/Server/' \
+        > /etc/pacman.d/mirrorlist.backup \
+        && rankmirrors -n 10 /etc/pacman.d/mirrorlist.backup \
+        > /etc/pacman.d/mirrorlist
+
 RUN echo "[multilib]" >> /etc/pacman.conf
 RUN echo "Include = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 

--- a/apktool/install
+++ b/apktool/install
@@ -1,8 +1,11 @@
 #!/bin/bash -ex
+VERSION=2.2.4
+
 mkdir bin
+cd bin
 wget https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool
-wget https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.2.2.jar
-mv apktool_2.2.2.jar bin/apktool.jar
-mv apktool bin/
-chmod 755 bin/apktool
-chmod 755 bin/apktool.jar
+wget "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_$VERSION.jar"
+ln -s "apktool_$VERSION.jar" apktool.jar
+chmod 755 apktool
+chmod 755 apktool.jar
+cd ..

--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -146,15 +146,28 @@ function base_build_setup()
 
 	## setup PATH for several shells
 
-	echo "export PATH=\"$PWD/bin:\$PATH\"" >> ~/.bashrc
+	MAGIC="# ctf-tools: PATH setup"
+	# make sure at least bashrc exists in case of plain VM setup
+	touch ~/.bashrc
 
-	if [ -e ~/.zshrc ]
-	then
-		echo "export PATH=\"$PWD/bin:\$PATH\"" >> ~/.zshrc
-	fi
+	for f in ~/.bashrc ~/.zshrc; do
+		if [[ -e "$f" ]]; then
+			if ! grep "$MAGIC" "$f" >/dev/null 2>&1; then
+				cat >> "$f" << EOF
+$MAGIC
+export PATH=$PWD/bin:\$PATH
+EOF
+			fi
+		fi
+	done
 
-	if [ -e ~/.config/fish/config.fish ]; then
-		echo "set -x PATH $PWD/bin \$PATH " >> ~/.config/fish/config.fish
+	if [[ -e "$f" ]]; then
+		if ! grep "$MAGIC" "$f" >/dev/null 2>&1; then
+			cat >> "$f" << EOF
+$MAGIC
+set -x PATH $PWD/bin \$PATH
+EOF
+		fi
 	fi
 
 	if [[ ! -e "$PWD/bin/ctf-tools-pip3" ]]; then

--- a/binwalk/install
+++ b/binwalk/install
@@ -3,5 +3,6 @@
 git clone --depth 1 https://github.com/devttys0/binwalk.git
 ctf-tools-pip install -e binwalk
 
+source ctf-tools-venv-activate
 mkdir -p bin
 ln -s $VIRTUAL_ENV/bin/binwalk bin

--- a/binwalk/uninstall
+++ b/binwalk/uninstall
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+ctf-tools-pip uninstall -y binwalk || true

--- a/gdb/install
+++ b/gdb/install
@@ -1,12 +1,18 @@
 #!/bin/bash -ex
 set -e -o pipefail
 
-curl https://ftp.gnu.org/gnu/gdb/gdb-7.12.1.tar.gz | tar xz
-cd gdb-7.12.1
+VERSION=8.0
+
+curl "https://ftp.gnu.org/gnu/gdb/gdb-$VERSION.tar.gz" | tar xz
+cd "gdb-$VERSION"
 
 # move to ctftools virtual env
 source ctf-tools-venv-activate
 
-./configure --prefix=$(dirname $PWD) --with-python=$(which python) --enable-targets=all
+./configure \
+    --prefix=$(dirname $PWD) \
+    --with-python=$(which python) \
+    --enable-targets=all \
+    --with-guile=guile-2.0
 make -j $(nproc)
 make install

--- a/gdb/install-root-debian
+++ b/gdb/install-root-debian
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 set -eu -o pipefail
 
-apt-get -y install texinfo
+apt-get -y install texinfo guile-2.0-dev

--- a/keystone/install
+++ b/keystone/install
@@ -1,5 +1,4 @@
 #!/bin/bash -ex
 
-ctf-tools-pip install -U keystone
-# seems to be broken?
-#ctf-tools-pip3 install -U keystone
+ctf-tools-pip install -U keystone-engine
+ctf-tools-pip3 install -U keystone-engine

--- a/pwntools/install-root-ubuntu
+++ b/pwntools/install-root-ubuntu
@@ -1,6 +1,11 @@
 #!/bin/bash -ex
 
-apt-get -y install software-properties-common
-apt-add-repository -y ppa:pwntools/binutils
-apt-get update
-apt-get -y install binutils-.*-linux-gnu libffi-dev libssl-dev
+apt-get install -y python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential
+
+if [[ $(lsb_release -rs | sed 's/\(..\)\.../\1/') -lt 16 ]]; then 
+    echo "using pwntools binutils ppa for pre-xenial ubuntu"
+    apt-get -y install software-properties-common
+    apt-add-repository -y ppa:pwntools/binutils
+    apt-get update
+    apt-get -y install binutils-.*-linux-gnu 
+fi

--- a/zsteg/install
+++ b/zsteg/install
@@ -1,3 +1,27 @@
 #!/bin/bash -ex
 
 gem install --user-install zsteg
+
+GEM_BIN_PATH=$(gem environment | grep "USER INSTALL" | awk -F ': ' '{ print $2 }')/bin
+
+MAGIC="# ctf-tools: gem install"
+for f in ~/.bashrc ~/.zshrc; do
+    if [[ -e "$f" ]]; then
+        if ! grep "$MAGIC" "$f" >/dev/null 2>&1; then
+            cat >> "$f" << EOF
+$MAGIC
+export PATH=\$PATH:$GEM_BIN_PATH
+EOF
+        fi
+    fi
+done
+
+f=~/.config/fish/config.fish
+if [[ -e "$f" ]]; then
+    if ! grep "$MAGIC" "$f" >/dev/null 2>&1; then
+        cat >> "$f" << EOF
+$MAGIC
+set -x PATH \$PATH $GEM_BIN_PATH
+EOF
+    fi
+fi


### PR DESCRIPTION
some more updates

* Updated gdb and fixed build on archlinux (hopefully this doesn't break builds on ubuntu/fedora)
* fixed keystone install
* don't use pwntools binutils ppa on xenial and later
* apktool version bump
* Find fastest mirror in archlinux Dockerfile
* Fixes for #134 #135 
* don't add ctf-tools to PATH in .(bash|zsh)rc when `manage-tools setup` is called more than once