### PR TITLE
Add https & fix 404 link for gdb-heap

### DIFF
--- a/galois/install
+++ b/galois/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget http://web.eecs.utk.edu/~plank/plank/papers/CS-07-593/galois.tar
+wget https://web.eecs.utk.edu/~plank/plank/papers/CS-07-593/galois.tar
 
 mkdir -p galois
 cd galois

--- a/gdb-heap/install
+++ b/gdb-heap/install
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-git clone --depth=1 http://git.fedorahosted.org/git/gdb-heap.git || true
+git clone --depth=1 https://github.com/rogerhu/gdb-heap || true
 
 cd gdb-heap
 # make sure gdbinit exists
@@ -14,7 +14,7 @@ define init-gdb-heap
     python import sys; sys.path.append("$PWD"); import heap
 end
 document init-gdb-heap
-    Initializes the gdb-heap extension (https://fedorahosted.org/gdb-heap/)
+    Initializes the gdb-heap extension (https://github.com/rogerhu/gdb-heap)
 end
 ####
 

--- a/pyvmmonitor/install
+++ b/pyvmmonitor/install
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # retry because the server is not reliable
-wget -t 10 http://www.mediafire.com/download/bzmazee4bcysbi4/pyvmmonitor_1.0.1_linux.x86_64.tar.gz -O - | tar xvz
+wget -t 10 https://www.mediafire.com/download/bzmazee4bcysbi4/pyvmmonitor_1.0.1_linux.x86_64.tar.gz -O - | tar xvz
 
 mkdir -p bin
 cat <<END > bin/pyvmmonitor-ui


### PR DESCRIPTION
- Updated some links to use HTTPS instead of HTTP (issue #45 ).
- Fixed the link to the gdb-heap repository from the retiring `https://fedorahosted.org/gdb-heap/` to `https://github.com/rogerhu/gdb-heap`