### PR TITLE
parse latest version of qemu & gdb from their git repos

### DIFF
--- a/gdb/install
+++ b/gdb/install
@@ -1,7 +1,18 @@
 #!/bin/bash -ex
 set -e -o pipefail
 
-VERSION=8.0.1
+find_latest_gdb_version() {
+    git ls-remote --tags git://sourceware.org/git/binutils-gdb.git \
+        | grep -v users \
+        | grep -v '{}' \
+        | grep -oh 'gdb-[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\(\.[0-9]\{1,2\}\)\?-release' \
+        | sort --version-sort -r \
+        | sed 's/gdb-//g' \
+        | sed 's/-release//g' \
+        | head -n 1
+}
+
+VERSION=$(find_latest_gdb_version)
 
 curl "https://ftp.gnu.org/gnu/gdb/gdb-$VERSION.tar.gz" | tar xz
 cd "gdb-$VERSION"

--- a/qemu/install
+++ b/qemu/install
@@ -1,6 +1,15 @@
 #!/bin/bash -ex
 
-VERSION=v2.10.0
+find_latest_qemu_version() {
+    git ls-remote --tags git://git.qemu.org/qemu.git \
+        | grep -v '\-rc' \
+        | grep -oh 'v[0-9]\{1,2\}\.[0-9]\{1,2\}\.[0-9]\{1,2\}\(\.[0-9]\{0,2\}\)\?' \
+        | sort --version-sort -r \
+        | head -n 1
+}
+
+#VERSION=v2.10.1
+VERSION=$(find_latest_qemu_version)
 git clone --depth=1 -b "$VERSION" git://git.qemu-project.org/qemu.git
 
 source ctf-tools-venv-activate


### PR DESCRIPTION
it seems a new qemu version is out every couple of months or so, so it's kind of annoying to always version bump it in this repo. I whipped up a quick shell oneliner to get the latest version tag from the git repo and download that.  
same for gdb, because it was quickly copy-pasted.

