### PR TITLE
fix shebang

### DIFF
--- a/galois/install
+++ b/galois/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 wget https://web.eecs.utk.edu/~plank/plank/papers/CS-07-593/galois.tar
 

--- a/libc-database/install
+++ b/libc-database/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 [ -e libc-database ] || git clone https://github.com/niklasb/libc-database
 


### PR DESCRIPTION
manage-tools install galois
manage-tools install libc-database
failed.

↓reason
https://github.com/zardus/ctf-tools/blob/8982de556dfe7cdff4cf5ae260c6a3e7307fb86e/bin/manage-tools#L353-L358