### PR TITLE
Support symlinks to manage-tools

### DIFF
--- a/bin/ctf-tools-pip
+++ b/bin/ctf-tools-pip
@@ -5,5 +5,5 @@ set -e -o pipefail
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-which-directory-it-is-stored-in
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source $DIR/ctf-tools-venv-activate
+source "$DIR/ctf-tools-venv-activate"
 exec pip "$@"

--- a/bin/ctf-tools-test-action
+++ b/bin/ctf-tools-test-action
@@ -28,7 +28,7 @@ if [[ "$1" == "-d" ]]; then
     shift 2
 fi
 
-pushd $CTFTOOLS_DIR >/dev/null
+pushd "$CTFTOOLS_DIR" >/dev/null
 set -x
 sudo docker build \
     -t "$DOCKER_CONTAINER" \
@@ -36,6 +36,6 @@ sudo docker build \
     .
 
 sudo docker run --rm -it \
-    -v $CTFTOOLS_DIR:/home/ctf/tools:z \
+    -v "$CTFTOOLS_DIR:/home/ctf/tools:z" \
     "$DOCKER_CONTAINER" bash -c "/home/ctf/tools/bin/manage-tools $*"
 exit $?

--- a/bin/ctf-tools-venv-activate
+++ b/bin/ctf-tools-venv-activate
@@ -38,7 +38,7 @@ fi
 
 if [[ -z "${VIRTUAL_ENV+x}" || "$VIRTUAL_ENV" != "$VE_DIR" ]]; then
     if [[ -n "${VIRTUAL_ENV+x}" ]]; then
-        source ${VIRTUAL_ENV}/bin/activate
+        source "${VIRTUAL_ENV}/bin/activate"
         deactivate
     fi
     source "$VE_DIR/bin/activate"

--- a/bin/manage-tools
+++ b/bin/manage-tools
@@ -2,7 +2,9 @@
 set -eu -o pipefail
 # set -x
 
-CTF_TOOLS_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+
+CTF_TOOLS_ROOT="$(python -c "import os.path as p;x=p.realpath('$SCRIPT_PATH');x=p.dirname(x);print(x)")/.."
 
 
 function usage()
@@ -307,7 +309,7 @@ fi
 
 
 
-cd $(dirname "${BASH_SOURCE[0]}")/..
+cd "$CTF_TOOLS_ROOT"
 
 case $ACTION in
 	setup)


### PR DESCRIPTION
- minor - make `manage-tools` work if it's symlinked from elsewhere
- minor - shell quoting: support spaces/IFS chars in paths here and there