### PR TITLE
Fixed issue: setuptools keeps complaining about python2

### DIFF
--- a/bin/ctf-tools-pip3
+++ b/bin/ctf-tools-pip3
@@ -1,1 +1,9 @@
-ctf-tools-pip
+#!/bin/bash
+set -e -o pipefail
+#set -x
+
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-which-directory-it-is-stored-in
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $DIR/ctf-tools-venv-activate
+exec python3 -m pip "$@"


### PR DESCRIPTION
### Description:
On the system that has both python2 and python3 that have been running well together (like Kali Linux), it's unable to complete even the first step in setting up ctf-tools environment. When execute `bin/manage-tools setup` it always fails where setuptools complain about python2 (see details below).

```bash
kali@kali:/opt/ctf-tools$ bin/manage-tools setup
Hit:1 http://ftp.▪️▪️▪️▪️▪️▪️/pub/kali kali-rolling InRelease
Reading package lists... Done
/home/kali/.virtualenvs/ctftools/lib/python2.7/site-packages/pkg_resources/py2_warn.py:21: UserWarning: Setuptools will stop working on Python 2
************************************************************
You are running Setuptools on Python 2, which is no longer
supported and
>>> SETUPTOOLS WILL STOP WORKING <<<
in a subsequent release (no sooner than 2020-04-20).
Please ensure you are installing
Setuptools using pip 9.x or later or pin to `setuptools<45`
in your environment.
If you have done those things and are still encountering
this message, please follow up at
https://bit.ly/setuptools-py2-warning.
************************************************************
  sys.version_info < (3,) and warnings.warn(pre + "*" * 60 + msg + "*" * 60)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support 
```

### Analysis
The reason of this complaining is ctf-tools using the same script for both python2 and python3 environment and then forcing python2's pip to install setuptools even though setuptools can be (and is recommended) to installed with python3.

### Solution
The fix is specifically call pip for python3 by `python3 -m pip` instead of just `pip` as currently used for both `bin/ctf-tools-pip` and `bin/ctf-tools-pip3`.

### The Fix
Remove the symlink of `ctf-tools-pip3` (that pointed to `ctf-tools-pip`), copy the content from `ctf-tools-pip` and replace `exec pip` by `exec python3 -m pip`

### Result after fix
```bash
kali@kali:/opt/ctf-tools$ bin/manage-tools setup
[sudo] password for kali: 
Hit:1 http://ftp.▪️▪️▪️▪️▪️▪️/pub/kali kali-rolling InRelease
Reading package lists... Done
kali@kali:/opt/ctf-tools$ 
```