### PR TITLE
Added Webgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Installers for the following tools are included:
 | web | Directory | [mitmproxy](https://mitmproxy.org/) | CLI Web proxy and python library.  | <!--tool--><!--no-test-->
 | web | Directory | [sqlmap](http://sqlmap.org/) | SQL injection automation engine. | <!--tool--><!--test-->
 | web | Directory | [subbrute](https://github.com/TheRook/subbrute) | A DNS meta-query spider that enumerates DNS records, and subdomains. | <!--tool--><!--test-->
+| web | Library | [webgrep](https://github.com/dhondta/webgrep) | `grep` for Web pages, with JS deobfuscation, CSS unminifying and OCR on images. | <!--tool--><!--test-->
 | stego | apt | [pngtools](https://launchpad.net/ubuntu/+source/pngtools) | PNG's analysis tool. | <!--deb-tool-->
 | stego | Directory | [sound-visualizer](http://www.sonicvisualiser.org/) | Audio file visualization. | <!--tool--><!--failing-->
 | stego | Directory | [steganabara](http://www.caesum.com/handbook/stego.htm) | Another image stenography solver. | <!--tool--><!--test-->

--- a/webgrep/install
+++ b/webgrep/install
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+
+ctf-tools-pip3 install --upgrade 'git+https://github.com/dhondta/webgrep.git'

--- a/webgrep/install-root-archlinux
+++ b/webgrep/install-root-archlinux
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+set -eu -o pipefail
+
+pacman -Syu --needed --noconfirm binutils grep imagemagick perl-image-exiftool steghide tesseract

--- a/webgrep/install-root-debian
+++ b/webgrep/install-root-debian
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+set -eu -o pipefail
+
+apt-get -y install binutils grep imagemagick libimage-exiftool-perl steghide tesseract-ocr

--- a/webgrep/install-root-fedora
+++ b/webgrep/install-root-fedora
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+set -eu -o pipefail
+
+dnf install perl-Image-ExifTool.noarch
+dnf install -y binutils grep imagemagick steghide tesseract

--- a/webgrep/install-root-ubuntu
+++ b/webgrep/install-root-ubuntu
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+set -eu -o pipefail
+
+apt-get -y install binutils grep imagemagick exiftool steghide tesseract-ocr


### PR DESCRIPTION
[Webgrep](https://github.com/dhondta/webgrep) relies on the well-known [grep](https://linux.die.net/man/1/grep) tool for grepping Web pages. It binds nearly every option of the original tool and also provides additional features like deobfuscating Javascript or appyling OCR on images before grepping downloaded resources.