### PR TITLE
Fix elfkickers CI race by disabling parallel make

### DIFF
--- a/elfkickers/install
+++ b/elfkickers/install
@@ -2,6 +2,6 @@
 
 git clone --depth 1 https://github.com/BR903/ELFkickers
 cd ELFkickers
-make -j $(nproc)
+make -j1
 cd ..
 mv ELFkickers/bin ./bin


### PR DESCRIPTION
## Summary
- fix intermittent elfkickers build failure in CI (`toolcheck (elfkickers)`) caused by a parallel make race
- serialize the ELFkickers build in `elfkickers/install` by changing `make -j $(nproc)` to `make -j1`

## Why
`rebind` links against `../elfrw/libelfrw.a`, but ELFkickers upstream Makefile does not fully express dependency ordering under parallel builds. In CI this can cause:

`/usr/bin/ld: ../elfrw/libelfrw.a: error adding symbols: file format not recognized`

Running make single-threaded in this installer removes the race deterministically.

## Validation
- `bash -n elfkickers/install`
- cloned `BR903/ELFkickers` and ran `make -j1` successfully
- verified artifacts `elfrw/libelfrw.a` and `bin/rebind` are produced