### PR TITLE
Fix galois download: use updated UTK URL

### DIFF
--- a/galois/install
+++ b/galois/install
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-wget https://web.eecs.utk.edu/~plank/plank/papers/CS-07-593/galois.tar
+wget https://web.eecs.utk.edu/~jplank/plank/papers/CS-07-593/galois.tar
 
 mkdir -p galois
 cd galois


### PR DESCRIPTION
## Summary
- The galois download URL (`~plank/...`) times out, breaking the `toolcheck (galois)` CI job
- The same tarball is still hosted at the updated faculty path (`~jplank/...`)
- One-character fix: `~plank` → `~jplank`

## Test plan
- [x] Verified new URL returns HTTP 200 with correct content-type and size (266 KB tar)
- [ ] CI `toolcheck (galois)` should pass with the updated URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)