### PR TITLE
Fix beef and manticore CI installs

### DIFF
--- a/beef/install
+++ b/beef/install
@@ -3,7 +3,14 @@
 git clone --depth 1 https://github.com/beefproject/beef
 
 cd beef
-rm Gemfile.lock
+rm -f Gemfile.lock
+# Ubuntu noble ships Ruby 3.2, while upstream test gems require Ruby 3.3+.
+ruby <<'RUBY'
+gemfile = File.read("Gemfile")
+updated = gemfile.sub(/^group :test do\n.*?^end\n/m, "")
+abort "Could not remove BeEF test dependency group" if updated == gemfile
+File.write("Gemfile", updated)
+RUBY
 bundle install
 cd ..
 

--- a/manticore/install
+++ b/manticore/install
@@ -1,3 +1,14 @@
 #!/bin/bash -ex
 
-pipx install --python $(which pypy3) "manticore[native]"
+VENV="$PWD/venv"
+
+virtualenv -p "$(which pypy3)" "$VENV"
+"$VENV/bin/pip" install \
+	"protobuf<4" \
+	"rlp<3" \
+	"eth-utils<2" \
+	"manticore[native]"
+
+mkdir -p bin
+ln -sf ../venv/bin/manticore bin/manticore
+ln -sf ../venv/bin/manticore-verifier bin/manticore-verifier

--- a/manticore/install-root-debian
+++ b/manticore/install-root-debian
@@ -2,4 +2,4 @@
 
 set -eu -o pipefail
 
-apt-get -y install pypy3 pypy3-dev rustc cargo
+apt-get -y install pypy3 pypy3-dev rustc cargo virtualenv


### PR DESCRIPTION
## Summary
- strip BeEF upstream test dependencies before Bundler resolves runtime gems on Ubuntu noble
- install Manticore in a PyPy virtualenv instead of pipx and cap legacy Python dependencies for noble
- add virtualenv to Manticore system dependencies

## Verification
- bash -n beef/install manticore/install manticore/install-root-debian
- git diff --check
- docker build --progress=plain -t ctftools-ci/beef --build-arg PREINSTALL=beef .
- docker build --progress=plain -t ctftools-ci/manticore --build-arg PREINSTALL=manticore .
